### PR TITLE
Fix receiving large payloads in socket transport

### DIFF
--- a/rsb/transport/socket/__init__.py
+++ b/rsb/transport/socket/__init__.py
@@ -143,7 +143,7 @@ class BusConnection(rsb.eventprocessing.BroadcastProcessor):
                                '(size: {})'.format(len(size)))
         size = size[0] | size[1] << 8 | size[2] << 16 | size[3] << 24
         self._logger.debug('Receiving notification of size %d', size)
-        notification = self._socket.recv(size)
+        notification = self._socket.recv(size, socket.MSG_WAITALL)
         if not (len(notification) == size):
             raise RuntimeError(
                 'Short read when receiving notification payload')

--- a/test/transporttest.py
+++ b/test/transporttest.py
@@ -85,7 +85,7 @@ class TransportCheck(metaclass=abc.ABCMeta):
         # first an event that we do not want
         event = Event(EventId(uuid.uuid4(), 0))
         event.scope = Scope("/notGood")
-        event.data = "dummy data"
+        event.data = "x" * 600000
         event.data_type = str
         event.meta_data.sender_id = uuid.uuid4()
         outconnector.handle(event)
@@ -103,8 +103,8 @@ class TransportCheck(metaclass=abc.ABCMeta):
             receiver.result_event.meta_data = None
             assert receiver.result_event == event
 
-        inconnector.deactivate()
         outconnector.deactivate()
+        inconnector.deactivate()
 
     @pytest.mark.timeout(5)
     def test_pull_non_blocking(self):
@@ -156,15 +156,15 @@ class TransportCheck(metaclass=abc.ABCMeta):
         in_connector = self._get_in_push_connector(scope, activate=False)
         out_connector = self._get_out_connector(scope, activate=False)
 
-        out_configurator = rsb.eventprocessing.OutRouteConfigurator(
-            connectors=[out_connector])
         in_configurator = rsb.eventprocessing.InPushRouteConfigurator(
             connectors=[in_connector])
+        out_configurator = rsb.eventprocessing.OutRouteConfigurator(
+            connectors=[out_connector])
 
+        listener = create_listener(scope, configurator=in_configurator)
         publisher = create_informer(scope,
                                     data_type=str,
                                     configurator=out_configurator)
-        listener = create_listener(scope, configurator=in_configurator)
 
         receiver = SettingReceiver(scope)
         listener.add_handler(receiver)
@@ -206,8 +206,8 @@ class TransportCheck(metaclass=abc.ABCMeta):
                 receiver.result_event.meta_data.create_time
             assert sent_event == receiver.result_event
 
-        listener.deactivate()
         publisher.deactivate()
+        listener.deactivate()
 
     @pytest.mark.timeout(5)
     def test_user_pull_roundtrip(self):


### PR DESCRIPTION
Use a flag to ensure that all requested bytes are read from the socket.
Adds an appropriate test with a large enough payload. Moreover, the
tests are changed such that real socket communication is used instead of
the in-process bus.