### PR TITLE
Fix scope constant in introspection module

### DIFF
--- a/rsb/introspection/__init__.py
+++ b/rsb/introspection/__init__.py
@@ -468,7 +468,8 @@ class HostInfo:
 # IntrospectionSender
 
 
-BASE_SCOPE = rsb.Scope('/_rsb/introspection/')
+BASE_SCOPE = rsb.Scope('/__rsb/introspection/')
+
 PARTICIPANTS_SCOPE = BASE_SCOPE.concat(rsb.Scope('/participants/'))
 HOSTS_SCOPE = BASE_SCOPE.concat(rsb.Scope('/hosts/'))
 


### PR DESCRIPTION
Looks like it was damaged during the "Replace double underscores with a single one" change (954ee8b).